### PR TITLE
Add path and line to GH console output

### DIFF
--- a/src/NVika/BuildServers/GitHub.cs
+++ b/src/NVika/BuildServers/GitHub.cs
@@ -35,16 +35,21 @@ namespace NVika.BuildServers
                     break;
             }
 
+            var details = issue.Message;
+
             if (issue.FilePath != null)
             {
-                var file = issue.FilePath.Replace('\\', '/');
-                outputString.Append($"file={file},");
+                var absolutePath = issue.FilePath.Replace('\\', '/');
+                var relativePath = issue.Project != null ? issue.FilePath.Replace($"{issue.Project.Replace('\\', '/')}/", string.Empty) : absolutePath;
+
+                outputString.Append($"file={absolutePath},");
+                details = $"{issue.Message} in {relativePath} on line {issue.Line}";
             }
 
             if (issue.Offset != null)
                 outputString.Append($"col={issue.Offset.Start},");
 
-            outputString.Append($"line={issue.Line}::{issue.Message}");
+            outputString.Append($"line={issue.Line}::{details}");
 
             Console.WriteLine(outputString.ToString());
         }


### PR DESCRIPTION
For long diffs, annotations can be hard to search for. This adds the file/line details to the GitHub console output, following the format of the AppVeyor build server.

Current: https://github.com/smoogipoo/osu/runs/4101969123?check_suite_focus=true
![image](https://user-images.githubusercontent.com/1329837/140270872-c62ac4ce-6a01-4983-b7af-5a2cc543175b.png)

PR: https://github.com/smoogipoo/osu/runs/4101973354?check_suite_focus=true
![image](https://user-images.githubusercontent.com/1329837/140270947-e97a703e-01a5-4f0f-a767-2c2f163b5e3c.png)
