### PR TITLE
Add platform multi-targeting for .NET Core 3.1 and .NET 6.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,11 +28,6 @@ jobs:
         restore-keys: |
           nuget-
 
-    - name: Setup DotNet 3.1
-      uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: '3.1.x'
-
     - name: Setup DotNet 6.0
       uses: actions/setup-dotnet@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,15 @@ jobs:
         restore-keys: |
           nuget-
 
-    - name: Setup .NET Core
+    - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x
+        
+    - name: Setup .NET 6
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
 
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v0.9.11

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,15 +28,15 @@ jobs:
         restore-keys: |
           nuget-
 
-    - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v1
+    - name: Setup DotNet 3.1
+      uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 3.1.x
-        
-    - name: Setup .NET 6
-      uses: actions/setup-dotnet@v1
+        dotnet-version: '3.1.x'
+
+    - name: Setup DotNet 6.0
+      uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: '6.0.x'
 
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v0.9.11

--- a/src/NVika/NVika.csproj
+++ b/src/NVika/NVika.csproj
@@ -17,7 +17,7 @@
 		<PackageTags>report parsing build server inspectcode FxCop SARIF Roslyn Gendarme</PackageTags>
 		<PackageReleaseNotes>https://github.com/laedit/vika/releases</PackageReleaseNotes>
 		<IncludeSymbols>true</IncludeSymbols>
-    		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
 		<Deterministic>true</Deterministic>
 	</PropertyGroup>

--- a/src/NVika/NVika.csproj
+++ b/src/NVika/NVika.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
 		<ErrorLog>bin\$(Configuration)\$(TargetFramework)\static-analysis.sarif.json;version=2</ErrorLog>
 		<PackAsTool>true</PackAsTool>
 		<ToolCommandName>nvika</ToolCommandName>
@@ -16,8 +16,6 @@
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>report parsing build server inspectcode FxCop SARIF Roslyn Gendarme</PackageTags>
 		<PackageReleaseNotes>https://github.com/laedit/vika/releases</PackageReleaseNotes>
-		<IncludeSymbols>true</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
 		<Deterministic>true</Deterministic>
 	</PropertyGroup>

--- a/src/NVika/NVika.csproj
+++ b/src/NVika/NVika.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
 		<ErrorLog>bin\$(Configuration)\$(TargetFramework)\static-analysis.sarif.json;version=2</ErrorLog>
 		<PackAsTool>true</PackAsTool>
 		<ToolCommandName>nvika</ToolCommandName>
@@ -16,6 +16,8 @@
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>report parsing build server inspectcode FxCop SARIF Roslyn Gendarme</PackageTags>
 		<PackageReleaseNotes>https://github.com/laedit/vika/releases</PackageReleaseNotes>
+		<IncludeSymbols>true</IncludeSymbols>
+    		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
 		<Deterministic>true</Deterministic>
 	</PropertyGroup>

--- a/src/NVika/NVika.csproj
+++ b/src/NVika/NVika.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+		<TargetFrameworks>netcoreapp3.1</TargetFrameworks>
 		<ErrorLog>bin\$(Configuration)\$(TargetFramework)\static-analysis.sarif.json;version=2</ErrorLog>
 		<PackAsTool>true</PackAsTool>
 		<ToolCommandName>nvika</ToolCommandName>


### PR DESCRIPTION
Currently folks have to install .NET Core 3.1 in order to use the tool.

These changes should cause both a .NET Core 3.1 and .NET 6.0 version to be created and included in the generated NuGet package.