### PR TITLE
Publish as native aot on windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,15 +45,15 @@ jobs:
     - name: Echo version
       run: echo ${{ steps.gitversion.outputs.nuGetVersionV2 }}
 
-    - name: Test
-      run: dotnet test src --configuration Release --nologo --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
-
     - name: Build
       id: build
       run: |
         dotnet build src --configuration Release --no-restore
         echo "release_folder=./src/NVika/bin/Release/net8.0" >> "$GITHUB_OUTPUT"
 
+    - name: Test
+      run: dotnet test src --configuration Release --no-build --nologo --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+  
     - name: InspectCode Analysis - old xml
       run: |
         nuget install JetBrains.ReSharper.CommandLineTools -ExcludeVersion -OutputDirectory tools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,18 +15,6 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
 
     steps:
-    - name: Set color
-      id: color-selector
-      run: |
-        "SELECTED_COLOR=green" >> $env:GITHUB_OUTPUT
-    - name: Get color
-      env:
-        SELECTED_COLOR: ${{ steps.color-selector.outputs.SELECTED_COLOR }}
-      run: |
-        echo "The selected color is $env:SELECTED_COLOR"
-        echo "The selected color is ${{ steps.color-selector.outputs.SELECTED_COLOR }}"
-        exit 1
-
     - uses: actions/checkout@v4
 
     - name: Fetch all history for all tags and branches
@@ -61,8 +49,7 @@ jobs:
       id: build
       run: |
         dotnet build src --configuration Release --no-restore
-        echo "release_folder=./src/NVika/bin/Release/net8.0" >> "$GITHUB_OUTPUT"
-        "SELECTED_COLOR=green" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        echo "release_folder=./src/NVika/bin/Release/net8.0" >> $env:GITHUB_OUTPUT
 
     - name: Test
       run: dotnet test src --configuration Release --no-build --nologo --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set color
       id: color-selector
       run: |
-        "SELECTED_COLOR=green" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        "SELECTED_COLOR=green" >> $env:GITHUB_OUTPUT
     - name: Get color
       env:
         SELECTED_COLOR: ${{ steps.color-selector.outputs.SELECTED_COLOR }}
@@ -62,6 +62,7 @@ jobs:
       run: |
         dotnet build src --configuration Release --no-restore
         echo "release_folder=./src/NVika/bin/Release/net8.0" >> "$GITHUB_OUTPUT"
+        "SELECTED_COLOR=green" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
     - name: Test
       run: dotnet test src --configuration Release --no-build --nologo --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Build
       id: build
       run: |
-        dotnet build src --configuration Release --no-restore
+        dotnet build src --configuration Release
         echo "release_folder=./src/NVika/bin/Release/net8.0" >> $env:GITHUB_OUTPUT
 
     - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,9 @@ jobs:
     - name: Set color
       id: color-selector
       shell: cmd
-      run: echo "SELECTED_COLOR=green" >> "$GITHUB_OUTPUT"
+      run: |
+        echo "SELECTED_COLOR=green" >> "$GITHUB_OUTPUT"
+        type "$GITHUB_OUTPUT"
     - name: Get color
       env:
         SELECTED_COLOR: ${{ steps.color-selector.outputs.SELECTED_COLOR }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,10 @@ jobs:
       run: dotnet test src --configuration Release --nologo --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
 
     - name: Build
-      shell: powershell
-      run: dotnet build src --configuration Release --no-restore /p:Version=${{ steps.gitversion.outputs.nuGetVersionV2 }}
+      id: build
+      run: |
+        dotnet build src --configuration Release --no-restore
+        echo "{release_folder}=./src/NVika/bin/Release/net8.0" >> "$GITHUB_OUTPUT"
 
     - name: InspectCode Analysis - old xml
       run: |
@@ -75,7 +77,7 @@ jobs:
     - name: GendarmeAnalysis
       run: |
         nuget install mono.gendarme -ExcludeVersion -OutputDirectory tools
-        ./tools/Mono.Gendarme/tools/gendarme.exe --xml GendarmeReport.xml --ignore gendarme.ignore .\src\NVika\bin\Release\net8.0\NVika.exe
+        ./tools/Mono.Gendarme/tools/gendarme.exe --xml GendarmeReport.xml --ignore gendarme.ignore ${{ steps.build.outputs.release_folder }}/NVika.exe
 
     - uses: actions/upload-artifact@v4
       with:
@@ -83,30 +85,27 @@ jobs:
         name: GendarmeReport.xml
 
     - name: LaunchNVika
-      run: .\src\NVika\bin\Release\net8.0\NVika.exe --debug --includesource inspectcodereport.xml inspectcodereport.json ./src/NVika/bin/Release/net8.0/static-analysis.sarif.json GendarmeReport.xml
+      run: ${{ steps.build.outputs.release_folder }}/NVika.exe --debug --includesource inspectcodereport.xml inspectcodereport.json ${{ steps.build.outputs.release_folder }}/static-analysis.sarif.json GendarmeReport.xml
 
-    # - name: Create release notes
-      # run: |
-        # dotnet SemanticReleaseNotesParser -g=categories --debug -o="artifacts/ReleaseNotes.html" --pluralizecategoriestitle --includestyle
-        # dotnet SemanticReleaseNotesParser -g=categories --debug -t=environment -f=markdown --pluralizecategoriestitle
+    - name: Create Nuget package
+      run: dotnet pack src --configuration Release --nologo --no-build /p:Version=${{ steps.gitversion.outputs.nuGetVersionV2 }}
 
     - name: Create MSBuild package
       run: |
         Copy-Item -Path resources/icon.png -Destination src\NVika.MSBuild\
         mkdir src\NVika.MSBuild\tools\
-        Copy-Item -Path "src/NVika/bin/Release/net8.0/publish/*" -Destination src\NVika.MSBuild\tools\
+        Copy-Item -Path "${{ steps.build.outputs.release_folder }}/publish/*" -Destination src\NVika.MSBuild\tools\
         nuget pack src/NVika.MSBuild/NVika.MSBuild.nuspec -Version ${{ steps.gitversion.outputs.nuGetVersionV2 }} -OutputDirectory artifacts/nuget
 
     - name: Create netcore packages
       run: |
         mkdir ./artifacts/zips
-        Compress-Archive -Path src/NVika/bin/Release/net8.0/publish/* -DestinationPath "artifacts/zips/NVika.netcore.${{ steps.gitversion.outputs.nuGetVersionV2 }}.zip"
+        Compress-Archive -Path ${{ steps.build.outputs.release_folder }}/publish/* -DestinationPath "artifacts/zips/NVika.netcore.${{ steps.gitversion.outputs.nuGetVersionV2 }}.zip"
         Copy-Item -Path "src/NVika/bin/Release/NVika.${{ steps.gitversion.outputs.nuGetVersionV2 }}.nupkg" -Destination artifacts/nuget
 
     - name: Create windows version
       run: |
-        dotnet publish src/NVika --configuration Release --output ./publish --self-contained true --runtime win-x86 -p:PublishSingleFile=true -p:PublishTrimmed=true /p:PackAsTool=false /p:Version=${{ steps.gitversion.outputs.nuGetVersionV2 }}
-        # Copy-Item -Path "artifacts/ReleaseNotes.html" -Destination publish
+        dotnet publish src/NVika --configuration Release --output ./publish --runtime win-x86 -p:PublishAot=true -p:PublishSingleFile=true -p:PublishTrimmed=true /p:PackAsTool=false /p:Version=${{ steps.gitversion.outputs.nuGetVersionV2 }}
         Compress-Archive -Path publish/* -DestinationPath "artifacts/zips/NVika.win-x86.${{ steps.gitversion.outputs.nuGetVersionV2 }}.zip"
 
     - name: Create chocolatey version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
     - name: Get color
       env:
         SELECTED_COLOR: ${{ steps.color-selector.outputs.SELECTED_COLOR }}
+      shell: cmd
       run: |
         echo "The selected color is $SELECTED_COLOR"
         echo "The selected color is ${{ steps.color-selector.outputs.SELECTED_COLOR }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ jobs:
       id: color-selector
       run: |
         "SELECTED_COLOR=green" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-        type "$GITHUB_OUTPUT"
     - name: Get color
       env:
         SELECTED_COLOR: ${{ steps.color-selector.outputs.SELECTED_COLOR }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
     - name: Set color
       id: color-selector
+      shell: cmd
       run: echo "SELECTED_COLOR=green" >> "$GITHUB_OUTPUT"
     - name: Get color
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,18 +74,8 @@ jobs:
         path: inspectcodereport.json
         name: inspectcodereport.json
 
-    - name: GendarmeAnalysis
-      run: |
-        nuget install mono.gendarme -ExcludeVersion -OutputDirectory tools
-        ./tools/Mono.Gendarme/tools/gendarme.exe --xml GendarmeReport.xml --ignore gendarme.ignore ${{ steps.build.outputs.release_folder }}/NVika.exe
-
-    - uses: actions/upload-artifact@v4
-      with:
-        path: GendarmeReport.xml
-        name: GendarmeReport.xml
-
     - name: LaunchNVika
-      run: ${{ steps.build.outputs.release_folder }}/NVika.exe --debug --includesource inspectcodereport.xml inspectcodereport.json ${{ steps.build.outputs.release_folder }}/static-analysis.sarif.json GendarmeReport.xml
+      run: ${{ steps.build.outputs.release_folder }}/NVika.exe --debug --includesource inspectcodereport.xml inspectcodereport.json ${{ steps.build.outputs.release_folder }}/static-analysis.sarif.json
 
     - name: Create Nuget package
       run: dotnet pack src --configuration Release --nologo --no-build /p:Version=${{ steps.gitversion.outputs.nuGetVersionV2 }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
 
     - name: Create windows version
       run: |
-        dotnet publish src/NVika --configuration Release --output ./publish --runtime win-x64 -p:PublishAot=true -p:PublishSingleFile=true -p:PublishTrimmed=true /p:PackAsTool=false /p:Version=${{ steps.gitversion.outputs.nuGetVersionV2 }}
+        dotnet publish src/NVika --configuration Release --output ./publish --runtime win-x64 -p:PublishAot=true -p:PublishTrimmed=true /p:PackAsTool=false /p:Version=${{ steps.gitversion.outputs.nuGetVersionV2 }}
         Compress-Archive -Path publish/* -DestinationPath "artifacts/zips/NVika.win-x64.${{ steps.gitversion.outputs.nuGetVersionV2 }}.zip"
 
     - name: Create chocolatey version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,9 +75,11 @@ jobs:
         name: inspectcodereport.json
 
     - name: GendarmeAnalysis
+      env:
+        RELEASE_FOLDER: ${{ steps.build.outputs.release_folder }}
       run: |
         nuget install mono.gendarme -ExcludeVersion -OutputDirectory tools
-        ./tools/Mono.Gendarme/tools/gendarme.exe --xml GendarmeReport.xml --ignore gendarme.ignore ${{ steps.build.outputs.release_folder }}/NVika.exe
+        ./tools/Mono.Gendarme/tools/gendarme.exe --xml GendarmeReport.xml --ignore gendarme.ignore "$RELEASE_FOLDER/NVika.exe"
 
     - uses: actions/upload-artifact@v4
       with:
@@ -85,22 +87,28 @@ jobs:
         name: GendarmeReport.xml
 
     - name: LaunchNVika
-      run: ${{ steps.build.outputs.release_folder }}/NVika.exe --debug --includesource inspectcodereport.xml inspectcodereport.json ${{ steps.build.outputs.release_folder }}/static-analysis.sarif.json GendarmeReport.xml
+      env:
+        RELEASE_FOLDER: ${{ steps.build.outputs.release_folder }}
+      run: $RELEASE_FOLDER/NVika.exe --debug --includesource inspectcodereport.xml inspectcodereport.json $RELEASE_FOLDER/static-analysis.sarif.json GendarmeReport.xml
 
     - name: Create Nuget package
       run: dotnet pack src --configuration Release --nologo --no-build /p:Version=${{ steps.gitversion.outputs.nuGetVersionV2 }}
 
     - name: Create MSBuild package
+      env:
+        RELEASE_FOLDER: ${{ steps.build.outputs.release_folder }}
       run: |
         Copy-Item -Path resources/icon.png -Destination src\NVika.MSBuild\
         mkdir src\NVika.MSBuild\tools\
-        Copy-Item -Path "${{ steps.build.outputs.release_folder }}/publish/*" -Destination src\NVika.MSBuild\tools\
+        Copy-Item -Path "$RELEASE_FOLDER/publish/*" -Destination src\NVika.MSBuild\tools\
         nuget pack src/NVika.MSBuild/NVika.MSBuild.nuspec -Version ${{ steps.gitversion.outputs.nuGetVersionV2 }} -OutputDirectory artifacts/nuget
 
     - name: Create netcore packages
+      env:
+        RELEASE_FOLDER: ${{ steps.build.outputs.release_folder }}
       run: |
         mkdir ./artifacts/zips
-        Compress-Archive -Path ${{ steps.build.outputs.release_folder }}/publish/* -DestinationPath "artifacts/zips/NVika.netcore.${{ steps.gitversion.outputs.nuGetVersionV2 }}.zip"
+        Compress-Archive -Path $RELEASE_FOLDER/publish/* -DestinationPath "artifacts/zips/NVika.netcore.${{ steps.gitversion.outputs.nuGetVersionV2 }}.zip"
         Copy-Item -Path "src/NVika/bin/Release/NVika.${{ steps.gitversion.outputs.nuGetVersionV2 }}.nupkg" -Destination artifacts/nuget
 
     - name: Create windows version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '8.0.x'
 
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v1.1.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,17 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
 
     steps:
+    - name: Set color
+      id: color-selector
+      run: echo "SELECTED_COLOR=green" >> "$GITHUB_OUTPUT"
+    - name: Get color
+      env:
+        SELECTED_COLOR: ${{ steps.color-selector.outputs.SELECTED_COLOR }}
+      run: |
+        echo "The selected color is $SELECTED_COLOR"
+        echo "The selected color is ${{ steps.color-selector.outputs.SELECTED_COLOR }}"
+        exit 1
+
     - uses: actions/checkout@v4
 
     - name: Fetch all history for all tags and branches

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,16 +17,14 @@ jobs:
     steps:
     - name: Set color
       id: color-selector
-      shell: cmd
       run: |
-        echo "SELECTED_COLOR=green" >> "$GITHUB_OUTPUT"
+        "SELECTED_COLOR=green" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         type "$GITHUB_OUTPUT"
     - name: Get color
       env:
         SELECTED_COLOR: ${{ steps.color-selector.outputs.SELECTED_COLOR }}
-      shell: cmd
       run: |
-        echo "The selected color is $SELECTED_COLOR"
+        echo "The selected color is $env:SELECTED_COLOR"
         echo "The selected color is ${{ steps.color-selector.outputs.SELECTED_COLOR }}"
         exit 1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,12 +95,12 @@ jobs:
 
     - name: Create windows version
       run: |
-        dotnet publish src/NVika --configuration Release --output ./publish --runtime win-x86 -p:PublishAot=true -p:PublishSingleFile=true -p:PublishTrimmed=true /p:PackAsTool=false /p:Version=${{ steps.gitversion.outputs.nuGetVersionV2 }}
-        Compress-Archive -Path publish/* -DestinationPath "artifacts/zips/NVika.win-x86.${{ steps.gitversion.outputs.nuGetVersionV2 }}.zip"
+        dotnet publish src/NVika --configuration Release --output ./publish --runtime win-x64 -p:PublishAot=true -p:PublishSingleFile=true -p:PublishTrimmed=true /p:PackAsTool=false /p:Version=${{ steps.gitversion.outputs.nuGetVersionV2 }}
+        Compress-Archive -Path publish/* -DestinationPath "artifacts/zips/NVika.win-x64.${{ steps.gitversion.outputs.nuGetVersionV2 }}.zip"
 
     - name: Create chocolatey version
       run: |
-        $winVersionChecksum = (Get-FileHash "artifacts/zips/NVika.win-x86.${{ steps.gitversion.outputs.nuGetVersionV2 }}.zip" -Algorithm SHA256).Hash
+        $winVersionChecksum = (Get-FileHash "artifacts/zips/NVika.win-x64.${{ steps.gitversion.outputs.nuGetVersionV2 }}.zip" -Algorithm SHA256).Hash
         mkdir ./artifacts/chocolatey
         $installPath = "chocolatey/tools/chocolateyInstall.ps1"
         $originalContent = Get-Content $installPath
@@ -156,14 +156,14 @@ jobs:
           asset_name: NVika.netcore.${{ steps.get_version.outputs.version }}.zip
           asset_content_type: application/zip
     
-      - name: Upload Zip win-x86
+      - name: Upload Zip win-x64
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./artifact/zips/NVika.win-x86.${{ steps.get_version.outputs.version }}.zip
-          asset_name: NVika.win-x86.${{ steps.get_version.outputs.version }}.zip
+          asset_path: ./artifact/zips/NVika.win-x64.${{ steps.get_version.outputs.version }}.zip
+          asset_name: NVika.win-x64.${{ steps.get_version.outputs.version }}.zip
           asset_content_type: application/zip
 
       - name: Chocolatey push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
       id: build
       run: |
         dotnet build src --configuration Release --no-restore
-        echo "{release_folder}=./src/NVika/bin/Release/net8.0" >> "$GITHUB_OUTPUT"
+        echo "release_folder=./src/NVika/bin/Release/net8.0" >> "$GITHUB_OUTPUT"
 
     - name: InspectCode Analysis - old xml
       run: |
@@ -75,11 +75,9 @@ jobs:
         name: inspectcodereport.json
 
     - name: GendarmeAnalysis
-      env:
-        RELEASE_FOLDER: ${{ steps.build.outputs.release_folder }}
       run: |
         nuget install mono.gendarme -ExcludeVersion -OutputDirectory tools
-        ./tools/Mono.Gendarme/tools/gendarme.exe --xml GendarmeReport.xml --ignore gendarme.ignore "$RELEASE_FOLDER/NVika.exe"
+        ./tools/Mono.Gendarme/tools/gendarme.exe --xml GendarmeReport.xml --ignore gendarme.ignore ${{ steps.build.outputs.release_folder }}/NVika.exe
 
     - uses: actions/upload-artifact@v4
       with:
@@ -87,28 +85,22 @@ jobs:
         name: GendarmeReport.xml
 
     - name: LaunchNVika
-      env:
-        RELEASE_FOLDER: ${{ steps.build.outputs.release_folder }}
-      run: $RELEASE_FOLDER/NVika.exe --debug --includesource inspectcodereport.xml inspectcodereport.json $RELEASE_FOLDER/static-analysis.sarif.json GendarmeReport.xml
+      run: ${{ steps.build.outputs.release_folder }}/NVika.exe --debug --includesource inspectcodereport.xml inspectcodereport.json ${{ steps.build.outputs.release_folder }}/static-analysis.sarif.json GendarmeReport.xml
 
     - name: Create Nuget package
       run: dotnet pack src --configuration Release --nologo --no-build /p:Version=${{ steps.gitversion.outputs.nuGetVersionV2 }}
 
     - name: Create MSBuild package
-      env:
-        RELEASE_FOLDER: ${{ steps.build.outputs.release_folder }}
       run: |
         Copy-Item -Path resources/icon.png -Destination src\NVika.MSBuild\
         mkdir src\NVika.MSBuild\tools\
-        Copy-Item -Path "$RELEASE_FOLDER/publish/*" -Destination src\NVika.MSBuild\tools\
+        Copy-Item -Path "${{ steps.build.outputs.release_folder }}/publish/*" -Destination src\NVika.MSBuild\tools\
         nuget pack src/NVika.MSBuild/NVika.MSBuild.nuspec -Version ${{ steps.gitversion.outputs.nuGetVersionV2 }} -OutputDirectory artifacts/nuget
 
     - name: Create netcore packages
-      env:
-        RELEASE_FOLDER: ${{ steps.build.outputs.release_folder }}
       run: |
         mkdir ./artifacts/zips
-        Compress-Archive -Path $RELEASE_FOLDER/publish/* -DestinationPath "artifacts/zips/NVika.netcore.${{ steps.gitversion.outputs.nuGetVersionV2 }}.zip"
+        Compress-Archive -Path ${{ steps.build.outputs.release_folder }}/publish/* -DestinationPath "artifacts/zips/NVika.netcore.${{ steps.gitversion.outputs.nuGetVersionV2 }}.zip"
         Copy-Item -Path "src/NVika/bin/Release/NVika.${{ steps.gitversion.outputs.nuGetVersionV2 }}.nupkg" -Destination artifacts/nuget
 
     - name: Create windows version

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Right now it's just a tiny tool which parse analysis reports and send messages t
 ## Installation
 
 - [Zip netcore](https://github.com/laedit/SemanticReleaseNotesParser/releases): download and extract
-- [Zip win-x86](https://github.com/laedit/SemanticReleaseNotesParser/releases): download and extract
-- [Chocolatey (win-x86)](https://chocolatey.org/packages/nvika/): `choco install nvika`
+- [Zip win-x64](https://github.com/laedit/SemanticReleaseNotesParser/releases): download and extract
+- [Chocolatey (win-x64)](https://chocolatey.org/packages/nvika/): `choco install nvika`
 - [Dotnet tool](https://www.nuget.org/packages/NVika/):  `dotnet tool install NVika`
 - [MSBuild](https://www.nuget.org/packages/NVika.MSBuild/):  `Install-Package NVika.MSBuild`
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,6 @@
 # next
 
+- [#479](https://github.com/laedit/vika/pull/479) - Publish as native AOT on windows +enhancement
 - [#478](https://github.com/laedit/vika/pull/478) - Upgrade to .NET 8 +breaking
 - [#477](https://github.com/laedit/vika/pull/477) - Fix license on nuget +enhancement
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,6 @@
 # next
 
-- [#479](https://github.com/laedit/vika/pull/479) - Publish as native AOT on windows +enhancement
+- [#479](https://github.com/laedit/vika/pull/479) - Publish as native AOT on windows +breaking
 - [#478](https://github.com/laedit/vika/pull/478) - Upgrade to .NET 8 +breaking
 - [#477](https://github.com/laedit/vika/pull/477) - Fix license on nuget +enhancement
 

--- a/chocolatey/tools/chocolateyInstall.ps1
+++ b/chocolatey/tools/chocolateyInstall.ps1
@@ -1,4 +1,4 @@
 $packageName = 'NVika'
-$url = 'https://github.com/laedit/Vika/releases/download/v[version]/NVika.win-x86.[version].zip'
+$url = 'https://github.com/laedit/Vika/releases/download/v[version]/NVika.win-x64.[version].zip'
 
 Install-ChocolateyZipPackage -PackageName "$packageName" -Url "$url" -UnzipLocation "$(Split-Path -parent $MyInvocation.MyCommand.Definition)" -Checksum '[checksum]' -ChecksumType 'sha256'

--- a/src/NVika/NVika.csproj
+++ b/src/NVika/NVika.csproj
@@ -7,7 +7,6 @@
 		<PackAsTool>true</PackAsTool>
 		<ToolCommandName>nvika</ToolCommandName>
 		<Authors>laedit</Authors>
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Description>Tool - Parse analysis reports (InspectCode, ...) and send messages to build server or console.</Description>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
Also:
- switch to win-x64 - mandatory for AOT
- remove release notes generation commented part
- use github actions output to avoid having the target framework everywhere
- gendarme does not support .NET binary